### PR TITLE
Refactor date extraction to use DateTime class

### DIFF
--- a/app/helpers/helpers.php
+++ b/app/helpers/helpers.php
@@ -214,7 +214,8 @@ function get_date_spanish($date, $withYear = true, $withMonth = true)
         '12' => 'Diciembre'
     ];
 
-    $day = date('d', strtotime($date));
+    $dateObj = new DateTime($date);
+    $day = $dateObj->format('d');
 
     if (!$withMonth) {
         return $day;


### PR DESCRIPTION
Update the `get_date_spanish` function to utilize the DateTime class for extracting the day, improving code clarity and reliability.