### PR TITLE
Fix missing break in admin routes

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -73,6 +73,7 @@ switch ($path) {
         break;
     case '/admin/accepted/enroll':
         AcceptedController::enroll($method);
+        break;
     case '/admin/settings':
         SettingsController::index();
         break;


### PR DESCRIPTION
## Summary
- ensure `AcceptedController::enroll()` case doesn't fall through in `routes/admin.php`

## Testing
- `php tests/runtest` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68402da89ae8832ba9dfe7fe68388249