### PR TITLE
Fix README env file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This will start a server on port 8000.
 
 ### Accessing the database
 First, in order to access the database, **you must
-create an `.ENV` file** following the `.ENV.EXAMPLE` located in the root folder of this project.
+create an `.env` file** following the `.env.example` located in the root folder of this project.
 
 ## Creating Models, Views and Controllers
 You may generate automatically models, views


### PR DESCRIPTION
## Summary
- use lowercase `.env` references in the README for consistency

## Testing
- `php tests/runtest` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68402dadeaf0832b82d897246ad1419b