### PR TITLE
Add admin deletion for users without applications

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -188,6 +188,34 @@ class User extends Model
     }
 
     /**
+     * Retrieves all users that do not have an application associated.
+     *
+     * @return array Users without an application.
+     */
+    public static function withoutApplication()
+    {
+        try {
+            $users = self::allof('user');
+            $result = [];
+
+            foreach ($users as $user) {
+                try {
+                    $application = $user->application();
+                    if ($application === null) {
+                        $result[] = $user;
+                    }
+                } catch (ModelNotFoundException $notFound) {
+                    $result[] = $user;
+                }
+            }
+
+            return $result;
+        } catch (Exception $e) {
+            return [];
+        }
+    }
+
+    /**
      * This will delete every instance of this user on the database
      * */
     public function purge()

--- a/resources/views/modals/confirmDeleteNoAppUsersModal.php
+++ b/resources/views/modals/confirmDeleteNoAppUsersModal.php
@@ -1,0 +1,28 @@
+<!-- Main popup container with the form -->
+<div id="confirmDeleteNoAppUsersModal" class="modal">
+    <div class="modal-content">
+        <!-- Botón de cerrar -->
+        <span class="close-button" onclick="closeModal('confirmDeleteNoAppUsersModal')">
+            <i class="fas fa-times"></i>
+        </span>
+        <!-- Título de la ventana -->
+        <h2>
+            <i class="fas fa-user-minus"></i>
+            ¿Desea eliminar las cuentas sin solicitud?
+        </h2>
+
+        <form action="/admin/delete/no-application-users" method="POST">
+            <div class="form-group">
+                <p>Esta acción eliminará permanentemente las cuentas que nunca hayan enviado una solicitud. No se podrá revertir.</p>
+            </div>
+
+            <div class="modal-actions">
+                <a class="main-action-bright" onclick="closeModal('confirmDeleteNoAppUsersModal')">Cancelar</a>
+                <button type="submit" class="main-action-bright danger">
+                    <i class="fas fa-trash"></i>
+                    Confirmar
+                </button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/settings.php
+++ b/resources/views/settings.php
@@ -14,6 +14,7 @@ require __DIR__ . '/modals/confirmDeleteDeniedModal.php';
 require __DIR__ . '/modals/createAdminModal.php';
 require __DIR__ . '/modals/confirmDisableUnsolicitedModal.php';
 require __DIR__ . '/modals/confirmDisableAllModal.php';
+require __DIR__ . '/modals/confirmDeleteNoAppUsersModal.php';
 require __DIR__ . '/modals/editPicturesModal.php';
 require __DIR__ . '/modals/uploadLiabilityWaiver.php';
 ?>
@@ -137,6 +138,12 @@ require __DIR__ . '/modals/uploadLiabilityWaiver.php';
                     <div class="settings-block">
                         <p> Crear una cuenta de administrador </p>
                         <button class="main-action-bright primary" onclick="openModal('createAdminModal')"> Crear
+                        </button>
+                    </div>
+                    <div class="settings-block">
+                        <p> Eliminar cuentas sin solicitud </p>
+                        <button class="main-action-bright danger" onclick="openModal('confirmDeleteNoAppUsersModal')">
+                            Borrar
                         </button>
                     </div>
                     <!-- <div class="settings-block">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -108,6 +108,9 @@ switch ($path) {
     case '/admin/delete/application':
         ApplicationController::deleteApplication($method);
         break;
+    case '/admin/delete/no-application-users':
+        SettingsController::deleteUsersWithoutApplication($method);
+        break;
     case '/sessions/create':
 
     case '/sessions/update':


### PR DESCRIPTION
## Summary
- allow admin to remove users that never submitted an application
- add helper method to fetch users without applications
- expose new route `/admin/delete/no-application-users`
- add confirmation modal and button in settings

## Testing
- `find app routes -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find app/models -name '*.php' -print0 | xargs -0 -n1 php -l`
- `php tests/unit/AuthTest.php` *(fails: Failed opening required '../app/helpers/helpers.php')*


------
https://chatgpt.com/codex/tasks/task_e_684031371d2c832bb9070916e1fc4e32