### PR TITLE
Implement zip archive for requests

### DIFF
--- a/resources/views/modals/confirmArchiveModal.php
+++ b/resources/views/modals/confirmArchiveModal.php
@@ -15,7 +15,7 @@
         <form id="archiveForm" action="/admin/settings/archive" method="POST">
     
             <div class="form-group">
-                <p>Esta acción creará un documento con la información de las solicitudes actuales. Recuerde limpiar las listas para evitar documentos duplicados.</p>
+                <p>Esta acción descargará un archivo ZIP con todos los documentos de las solicitudes actuales. Recuerde limpiar las listas para evitar archivos duplicados.</p>
             </div>
 
             <div class="modal-actions">


### PR DESCRIPTION
## Summary
- update `archive` controller action to generate a zip with users' documents
- refresh text in `confirmArchiveModal` to mention the new zip export

## Testing
- `php tests/runtest` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684055987f84832b921c9c4c044a53f0